### PR TITLE
Update downloads section to reflect new release system

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -133,6 +133,17 @@ td.is-grey {
     padding: 0;
 }
 
+.latest-downloads {
+}
+
+.latest-downloads-group {
+    display: inline-block;
+    line-height: 1rem;
+}
+
+.latest-downloads-group-sub {
+    font-size: 0.8rem;
+}
 
 @media screen and (max-width: 768px) {
     #login-button-text { display: none }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -145,6 +145,12 @@ td.is-grey {
     font-size: 0.8rem;
 }
 
+.downloads-button {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+    margin-right: 0.5rem;
+}
+
 @media screen and (max-width: 768px) {
     #login-button-text { display: none }
     #login-button { padding-right: 2px }

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -137,10 +137,29 @@ tab = "home"
             </article>
             <div class="columns">
                 <div class="column is-half">
-                    <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Latest version</h4>
-                    <a class="button is-primary is-medium" style="color: white;" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.12.2</span></a>
-                    <div class="" style="margin-top: 2rem">
-                        <h4>Maven</h4>
+                    <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Supported versions</h4>
+                    <div class="latest-downloads">
+                        <div class="latest-downloads-group">
+                            <a class="button is-success is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
+                            <br>
+                            <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
+                        </div>
+                        <!-- Uncomment this when 2018.1.0 is released
+                        <div class="latest-downloads-group">
+                            <a class="button is-success is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.1.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Release 2018.1.0</span></a>
+                            <br>
+                            <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
+                        </div>
+                        -->
+                        <div class="latest-downloads-group">
+                            <a class="button is-warning is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
+                            <br>
+                            <span class="latest-downloads-group-sub">MC 1.12.2</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-half">
+                    <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Maven</h4>
                         <p>You can use Glowstone and Glowkit as Maven dependencies directly from our <a href="https://repo.glowstone.net/#browse~snapshots/net.glowstone" target="_blank">repository</a>:</p>
                         <pre><code style="padding: 0 1.5rem">
 &lt;repository&gt;
@@ -148,29 +167,6 @@ tab = "home"
     &lt;url&gt;https://repo.glowstone.net/content/repositories/snapshots/&lt;/url&gt;
 &lt;/repository&gt;
                         </code></pre>
-                    </div>
-                </div>
-                <div class="column is-half">
-                    <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Previous versions</h4>
-                    <p>These versions are no longer supported or developed. They may lack important fixes and features.</p>
-                    <h4 class="title is-5" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Previous Minecraft versions (not recommended)</h4>
-
-                    <a class="button is-warning" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2017.9.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.12.1</span></a>
-                    <a class="button is-warning" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2017.8.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.12</span></a>
-                    <a class="button is-warning" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2017.6.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.11.2</span></a>
-
-                    <br />
-
-                    <a class="button is-warning" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/v1.10.2/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.10.2</span></a>
-                    <a class="button is-warning" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/1.9.4/glowstone.-1.9.4-SNAPSHOT.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.9.x</span></a>
-
-                    <br />
-
-                    <h4 class="title is-5" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Legacy versions (not recommended)</h4>
-                    <p>Legacy builds dating from the original Glowstone <a href="https://github.com/GlowstoneMC/Glowstone-Legacy">repository</a>.</p>
-
-                    <a class="button is-danger" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone-Legacy/releases/download/1.7.9/glowstone-1.7.9-SNAPSHOT.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.7.9</span></a>
-                    <a class="button is-danger" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone-Legacy/releases/download/1.7.2/glowstone-1.7.2-SNAPSHOT.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Download for 1.7.2</span></a>
                 </div>
             </div>
         </div>

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -140,19 +140,19 @@ tab = "home"
                     <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Supported versions</h4>
                     <div class="latest-downloads">
                         <div class="latest-downloads-group">
-                            <a class="button is-success is-large downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
+                            <a class="button is-success is-medium downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="https://glowstone.net/news/13">Changelog</a></span>
                         </div>
                         <!-- Uncomment this when 2018.1.0 is released
                         <div class="latest-downloads-group">
-                            <a class="button is-success is-large downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.1.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Release 2018.1.0</span></a>
+                            <a class="button is-success is-medium downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.1.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Release 2018.1.0</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
                         </div>
                         -->
                         <div class="latest-downloads-group">
-                            <a class="button is-warning is-large downloads-button" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=2018.1.0-SNAPSHOT&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
+                            <a class="button is-warning is-medium downloads-button" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=2018.1.0-SNAPSHOT&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="https://github.com/GlowstoneMC/Glowstone/tree/dev">dev branch</a></span>
                         </div>

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -140,7 +140,7 @@ tab = "home"
                     <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Supported versions</h4>
                     <div class="latest-downloads">
                         <div class="latest-downloads-group">
-                            <a class="button is-success is-large downloads-button"  href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
+                            <a class="button is-success is-large downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
                         </div>
@@ -152,7 +152,7 @@ tab = "home"
                         </div>
                         -->
                         <div class="latest-downloads-group">
-                            <a class="button is-warning is-large downloads-button"  href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
+                            <a class="button is-warning is-large downloads-button" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2</span>
                         </div>
@@ -183,10 +183,19 @@ tab = "home"
                     <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Maven</h4>
                         <p>You can use Glowstone and Glowkit as Maven dependencies directly from our <a href="https://repo.glowstone.net/#browse~snapshots/net.glowstone" target="_blank">repository</a>:</p>
                         <pre><code style="padding: 0 1.5rem">
+&lt;!-- Glowstone Maven snapshot repository --&gt;
 &lt;repository&gt;
     &lt;id&gt;glowstone-repo&lt;/id&gt;
     &lt;url&gt;https://repo.glowstone.net/content/repositories/snapshots/&lt;/url&gt;
 &lt;/repository&gt;
+                        </code></pre>
+                        <pre><code style="padding: 0 1.5rem">
+&lt;!-- Glowstone server dependency --&gt;
+&lt;dependency&gt;
+    &lt;groupId&gt;net.glowstone&lt;/groupId&gt;
+    &lt;artifactId&gt;glowstone&lt;/artifactId&gt;
+    &lt;version&gt;2018.0.0&lt;/version&gt;
+&lt;/dependency&gt;
                         </code></pre>
                 </div>
             </div>

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -142,7 +142,7 @@ tab = "home"
                         <div class="latest-downloads-group">
                             <a class="button is-success is-large downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
                             <br>
-                            <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
+                            <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="https://glowstone.net/news/13">Changelog</a></span>
                         </div>
                         <!-- Uncomment this when 2018.1.0 is released
                         <div class="latest-downloads-group">
@@ -152,9 +152,9 @@ tab = "home"
                         </div>
                         -->
                         <div class="latest-downloads-group">
-                            <a class="button is-warning is-large downloads-button" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
+                            <a class="button is-warning is-large downloads-button" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=2018.1.0-SNAPSHOT&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
                             <br>
-                            <span class="latest-downloads-group-sub">MC 1.12.2</span>
+                            <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="https://github.com/GlowstoneMC/Glowstone/tree/dev">dev branch</a></span>
                         </div>
                     </div>
                     <div style="margin-top: 2rem">

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -140,21 +140,42 @@ tab = "home"
                     <h4 class="title is-4" style="margin-top: 1.5rem; margin-bottom: 0.5rem">Supported versions</h4>
                     <div class="latest-downloads">
                         <div class="latest-downloads-group">
-                            <a class="button is-success is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
+                            <a class="button is-success is-large downloads-button"  href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.0.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>LTS 2018.0.0</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
                         </div>
                         <!-- Uncomment this when 2018.1.0 is released
                         <div class="latest-downloads-group">
-                            <a class="button is-success is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.1.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Release 2018.1.0</span></a>
+                            <a class="button is-success is-large downloads-button" href="https://github.com/GlowstoneMC/Glowstone/releases/download/2018.1.0/glowstone.jar"><span class="icon"><i class="fa fa-download"></i></span> <span>Release 2018.1.0</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2 | <a href="GIVE LINK PLEASE">Changelog</a></span>
                         </div>
                         -->
                         <div class="latest-downloads-group">
-                            <a class="button is-warning is-medium" style="margin-top: 0.25rem; margin-bottom: 0.25rem; margin-right: 0.5rem;" href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
+                            <a class="button is-warning is-large downloads-button"  href="https://repo.glowstone.net/restServices/archivaServices/searchService/artifact?g=net.glowstone&a=glowstone&v=LATEST&r=snapshots"><span class="icon"><i class="fa fa-download"></i></span> <span>Latest build</span></a>
                             <br>
                             <span class="latest-downloads-group-sub">MC 1.12.2</span>
+                        </div>
+                    </div>
+                    <div style="margin-top: 2rem">
+                        <h4>Plugins</h4>
+                        <p>
+                            Glowstone natively supports plugins written for the Bukkit, Spigot and Paper APIs.
+                            Simply place the Java archives (.jar) in your server's <code>plugins</code> directory and run Glowstone.
+                        </p>
+                        <p>
+                            Note that plugins that use platform-dependent code (NMS, OBC, etc.) will not run on Glowstone.
+                        </p>
+                        <div class="latest-downloads">
+                            <div class="latest-downloads-group">
+                                <a class="button downloads-button" href="https://dev.bukkit.org/bukkit-plugins"><span>Bukkit plugins</span></a>
+                            </div>
+                            <div class="latest-downloads-group">
+                                <a class="button downloads-button" href="https://www.spigotmc.org/resources/categories/bukkit.4/?order=download_count"><span>Spigot plugins</span></a>
+                            </div>
+                            <div class="latest-downloads-group">
+                                <a class="button downloads-button" href="https://aquifermc.org/resources/categories/server-plugins.2/?order=download_count"><span>Paper plugins</span></a>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This should be merged when Glowstone `2018.0.0` is released on Jan 1.

It adds a separate download button for LTS (2018.0.x) and latest builds. Previous and legacy downloads are also removed, and a section about plugin downloads is added.

Preview:


![image](https://user-images.githubusercontent.com/6775216/34465162-c41e3ac8-ee6f-11e7-8119-609ecb75755c.png)
