### PR TITLE
Update homepage "Paper plugins" link

### DIFF
--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -172,7 +172,7 @@ tab = "home"
                                 <a class="button downloads-button" href="https://www.spigotmc.org/resources/categories/bukkit.4/?order=download_count"><span>Spigot plugins</span></a>
                             </div>
                             <div class="latest-downloads-group">
-                                <a class="button downloads-button" href="https://aquifermc.org/resources/categories/server-plugins.2/?order=download_count"><span>Paper plugins</span></a>
+                                <a class="button downloads-button" href="https://papermc.io/forums/c/plugin-releases/paper"><span>Paper plugins</span></a>
                             </div>
                             <div class="latest-downloads-group">
                                 <a class="button downloads-button" href="https://forums.glowstone.net/category/6/plugins"><span>Glowstone plugins</span></a>


### PR DESCRIPTION
The AquiferMC forums was replaced by the [PaperMC site and forums](https://papermc.io) recently, so this PR updates the **Paper plugins** link to point to the [new forums category for Paper plugins](https://papermc.io/forums/c/plugin-releases/paper).